### PR TITLE
Implement dark mode support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import Account from './pages/Account'
 function App() {
   return (
     <Router>
-      <div className="min-h-screen bg-gray-50">
+      <div className="min-h-screen bg-gray-50 dark:bg-black dark:text-gray-100">
         <main className="pb-20 safe-area-bottom">
           <Routes>
             <Route path="/" element={<Home />} />

--- a/src/components/layout/BottomNavigation.tsx
+++ b/src/components/layout/BottomNavigation.tsx
@@ -54,7 +54,7 @@ export default function BottomNavigation() {
   const location = useLocation()
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 bg-white/95 backdrop-blur-xl border-t border-gray-200/50 z-50 safe-area-bottom">
+    <div className="fixed bottom-0 left-0 right-0 bg-white/95 dark:bg-gray-800/90 backdrop-blur-xl border-t border-gray-200/50 dark:border-gray-700/50 z-50 safe-area-bottom">
       <div className="flex justify-around px-2 py-1">
         {navItems.map((item, index) => {
           const isActive = location.pathname === item.href
@@ -64,13 +64,13 @@ export default function BottomNavigation() {
               to={item.href}
               className={`flex flex-col items-center py-2 px-3 rounded-xl transition-all-smooth relative stagger-item hover-lift ${
                 isActive 
-                  ? 'text-blue-600' 
-                  : 'text-gray-500 hover:text-gray-900'
+                  ? 'text-blue-600'
+                  : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-50'
               }`}
               style={{ animationDelay: `${index * 0.05}s` }}
             >
               {isActive && (
-                <div className="absolute inset-0 bg-blue-50 rounded-xl animate-scale-in" />
+                <div className="absolute inset-0 bg-blue-50 dark:bg-blue-900/40 rounded-xl animate-scale-in" />
               )}
               <div className="relative z-10 flex flex-col items-center">
                 <IconComponent icon={item.icon} isActive={isActive} />

--- a/src/components/layout/FixedHeader.tsx
+++ b/src/components/layout/FixedHeader.tsx
@@ -33,19 +33,19 @@ export default function FixedHeader({ title, subtitle, children, className = '' 
 
   return (
     <div className={`fixed top-0 left-0 right-0 z-40 transition-all duration-300 ${className}`}>
-      <div className={`bg-white/95 backdrop-blur-sm border-b border-gray-200 transition-all duration-300 ${
+      <div className={`bg-white/95 dark:bg-gray-800/90 backdrop-blur-sm border-b border-gray-200 dark:border-gray-700 transition-all duration-300 ${
         isScrolled ? 'py-2 shadow-lg' : 'py-4 shadow-sm'
       }`}>
         <div className="px-4 max-w-6xl mx-auto">
           <div className="flex items-center justify-between">
             <div className={`transition-all duration-300 ${isScrolled ? 'scale-90' : 'scale-100'}`}>
-              <h1 className={`font-bold text-gray-900 transition-all duration-300 ${
+              <h1 className={`font-bold text-gray-900 dark:text-gray-100 transition-all duration-300 ${
                 isScrolled ? 'text-lg' : 'text-2xl'
               }`}>
                 {title}
               </h1>
               {subtitle && !isScrolled && (
-                <p className="text-gray-600 text-sm mt-1 transition-opacity duration-300">
+                <p className="text-gray-600 dark:text-gray-300 text-sm mt-1 transition-opacity duration-300">
                   {subtitle}
                 </p>
               )}

--- a/src/components/layout/IOSHeader.tsx
+++ b/src/components/layout/IOSHeader.tsx
@@ -29,8 +29,8 @@ export function IOSActionButton({
       className={`
         flex items-center justify-center w-11 h-11 rounded-full transition-all duration-200 
         ${variant === 'primary' 
-          ? 'bg-blue-600 text-white hover:bg-blue-700 active:bg-blue-800' 
-          : 'bg-gray-100/80 text-gray-700 hover:bg-gray-200/80 active:bg-gray-300/80'
+          ? 'bg-blue-600 text-white hover:bg-blue-700 active:bg-blue-800'
+          : 'bg-gray-100/80 text-gray-700 hover:bg-gray-200/80 active:bg-gray-300/80 dark:bg-gray-700/70 dark:text-gray-100 dark:hover:bg-gray-600/70 dark:active:bg-gray-500/70'
         }
         hover:scale-105 active:scale-95
         focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
@@ -67,9 +67,9 @@ export default function IOSHeader({
     <header 
       className={`
         fixed top-0 left-0 right-0 z-40 transition-all duration-300
-        ${isScrolled 
-          ? 'bg-white/95 backdrop-blur-xl border-b border-gray-200/50 shadow-sm' 
-          : 'bg-white/80 backdrop-blur-md'
+        ${isScrolled
+          ? 'bg-white/95 dark:bg-gray-800/90 backdrop-blur-xl border-b border-gray-200/50 dark:border-gray-700/50 shadow-sm'
+          : 'bg-white/80 dark:bg-gray-800/80 backdrop-blur-md'
         }
         safe-area-top
         ${className}
@@ -95,11 +95,11 @@ export default function IOSHeader({
 
         {/* Title Section */}
         <div className="mb-2">
-          <h1 className="text-2xl font-bold text-gray-900 leading-tight tracking-tight">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 leading-tight tracking-tight">
             {title}
           </h1>
           {subtitle && (
-            <p className="text-base text-gray-600 mt-1 leading-relaxed">
+            <p className="text-base text-gray-600 dark:text-gray-300 mt-1 leading-relaxed">
               {subtitle}
             </p>
           )}

--- a/src/index.css
+++ b/src/index.css
@@ -11,7 +11,7 @@
   }
   
   body {
-    @apply bg-gray-50 text-gray-900 antialiased;
+    @apply bg-gray-50 text-gray-900 antialiased dark:bg-gray-900 dark:text-gray-100;
     font-feature-settings: 'cv01', 'cv02', 'cv03', 'cv04';
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -26,7 +26,7 @@ export default function Account() {
 
   if (!currentUser) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
         <Card className="w-full max-w-md">
           <CardContent className="text-center py-8">
             <svg className="w-16 h-16 text-gray-400 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -76,9 +76,9 @@ export default function Account() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-50 via-white to-pink-50">
+    <div className="min-h-screen bg-gradient-to-br from-purple-50 via-white to-pink-50 dark:bg-gray-900 dark:bg-none">
       {/* Header */}
-      <div className="sticky top-0 z-30 bg-white border-b border-gray-200 shadow-sm">
+      <div className="sticky top-0 z-30 bg-white border-b border-gray-200 shadow-sm dark:bg-gray-800 dark:border-gray-700">
         <div className="px-4 py-4">
           <div className="max-w-4xl mx-auto">
             <h1 className="text-xl font-bold text-gray-900">Account</h1>

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -77,7 +77,7 @@ export default function Calendar() {
   }
 
   return (
-    <div className="min-h-screen bg-white flex flex-col">
+    <div className="min-h-screen bg-white dark:bg-gray-900 flex flex-col">
       {/* iOS Calendar Header */}
       <IOSHeader 
         title="Calendar"

--- a/src/pages/Documents.tsx
+++ b/src/pages/Documents.tsx
@@ -150,9 +150,9 @@ export default function Documents() {
   const currentFolders = getCurrentFolders()
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-emerald-50">
+    <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-emerald-50 dark:bg-gray-900 dark:bg-none">
       {/* Header */}
-      <div className="sticky top-0 z-30 bg-white border-b border-gray-200 shadow-sm">
+      <div className="sticky top-0 z-30 bg-white border-b border-gray-200 shadow-sm dark:bg-gray-800 dark:border-gray-700">
         <div className="px-4 py-4">
           <div className="max-w-6xl mx-auto">
             <div className="flex items-center justify-between mb-4">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -23,7 +23,7 @@ export default function Home() {
 
   if (!currentUser) {
     return (
-      <div className="min-h-screen bg-gray-50 pb-20 flex items-center justify-center">
+      <div className="min-h-screen bg-gray-50 pb-20 flex items-center justify-center dark:bg-gray-900">
         <Card className="w-full max-w-md mx-4">
           <CardContent className="text-center py-8">
             <h2 className="text-xl font-semibold text-gray-900 mb-4">Welcome to Errolian Club</h2>
@@ -49,7 +49,7 @@ export default function Home() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:bg-gray-900 dark:bg-none">
       {/* iOS Header */}
       <IOSHeader 
         title={getGreeting()} 

--- a/src/pages/SplitPay.tsx
+++ b/src/pages/SplitPay.tsx
@@ -85,7 +85,7 @@ export default function SplitPay() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-white to-yellow-50">
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-white to-yellow-50 dark:bg-gray-900 dark:bg-none">
       {/* iOS Header */}
       <IOSHeader 
         title="Split-Pay"

--- a/src/pages/SplitPayEventDetails.tsx
+++ b/src/pages/SplitPayEventDetails.tsx
@@ -27,7 +27,7 @@ export default function SplitPayEventDetails() {
   
   if (!event) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
         <div className="text-center">
           <h2 className="text-xl font-semibold text-gray-900 mb-2">Event Not Found</h2>
           <Button onClick={() => navigate('/split-pay')}>
@@ -51,7 +51,7 @@ export default function SplitPayEventDetails() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-white to-yellow-50">
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-white to-yellow-50 dark:bg-gray-900 dark:bg-none">
       {/* Fixed Header */}
       <FixedHeader 
         title={event.title}


### PR DESCRIPTION
## Summary
- hook up global dark mode classes
- add dark-themed backgrounds and text
- style navigation and headers for dark mode

## Testing
- `npm run lint` *(fails: cannot pass existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68504d78dc98832cb6eb8c5265ed9053